### PR TITLE
InRequestVars + SeparateLogicalBlocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,49 @@ content-type: application/json
 If run on all files it also warns when it finds both `.env` and `http-client.env.json`
 files in the same directory, because that might cause unexpected behavior.
 
+## Formatting options
+
+Logical blocks can be separated by a newline using `--separatelogicalblocks`. For example:
+
+```http
+@variables1=value1
+
+# This is a comment
+# This is another comment
+
+# @someother metatag
+# @name REQUEST_NAME_ONE
+
+GET http://localhost:8080/api/v1/health HTTP/1.1
+Content-Type: application/json
+
+{
+  "key": "value"
+}
+```
+
+When using request variables (like optaining a token from a previous request) you may assign thie to a document after the request and don't force to put it at the top of the file.
+This can be done by using `--inrequestvars`
+
+```http
+###
+
+# @name login
+
+POST {{loginURL}} HTTP/1.1
+Accept: application/json
+Content-Type: application/x-www-form-urlencoded
+
+client_secret={{clientSecret}}&client_id={{clientId}}&grant_type=client_credentials&scope={{scope}}
+
+###
+
+@token = {{login.response.body.$.access_token}}
+@tokentype = {{login.response.body.$.token_type}}
+
+###
+```
+
 ## Use it with conform.nvim
 
 ```lua

--- a/README.md
+++ b/README.md
@@ -129,7 +129,11 @@ files in the same directory, because that might cause unexpected behavior.
 
 ## Formatting options
 
-Logical blocks can be separated by a newline using `--separatelogicalblocks`. For example:
+You can tweak the formatter by using some flags.
+
+### separate-logical-blocks
+
+Logical blocks can be separated by a newline using `--separate-logical-blocks`. For example:
 
 ```http
 @variables1=value1
@@ -148,8 +152,13 @@ Content-Type: application/json
 }
 ```
 
-When using request variables (like optaining a token from a previous request) you may assign thie to a document after the request and don't force to put it at the top of the file.
-This can be done by using `--inrequestvars`
+### in-request-vars
+
+When using request variables (like optaining a token from a previous request)
+you may assign thie to a document after the request and
+don't force to put it at the top of the file.
+
+This can be done by using `--in-request-vars`
 
 ```http
 ###

--- a/cmd/kulalafmt/root.go
+++ b/cmd/kulalafmt/root.go
@@ -41,4 +41,6 @@ func init() {
 	rootCmd.PersistentFlags().BoolVar(&cfg.Flags.Check, "check", false, "check")
 	rootCmd.PersistentFlags().BoolVar(&cfg.Flags.Verbose, "verbose", false, "verbose")
 	rootCmd.PersistentFlags().BoolVar(&cfg.Flags.Version, "version", false, "version")
+	rootCmd.PersistentFlags().BoolVar(&cfg.Flags.InRequestVars, "inrequestvars", false, "inrequestvars")
+	rootCmd.PersistentFlags().BoolVar(&cfg.Flags.SeparateLogicalBlocks, "separatelogicalblocks", false, "separatelogicalblocks")
 }

--- a/cmd/kulalafmt/root.go
+++ b/cmd/kulalafmt/root.go
@@ -41,6 +41,6 @@ func init() {
 	rootCmd.PersistentFlags().BoolVar(&cfg.Flags.Check, "check", false, "check")
 	rootCmd.PersistentFlags().BoolVar(&cfg.Flags.Verbose, "verbose", false, "verbose")
 	rootCmd.PersistentFlags().BoolVar(&cfg.Flags.Version, "version", false, "version")
-	rootCmd.PersistentFlags().BoolVar(&cfg.Flags.InRequestVars, "inrequestvars", false, "inrequestvars")
-	rootCmd.PersistentFlags().BoolVar(&cfg.Flags.SeparateLogicalBlocks, "separatelogicalblocks", false, "separatelogicalblocks")
+	rootCmd.PersistentFlags().BoolVar(&cfg.Flags.InRequestVars, "in-request-vars", false, "don't enforce document variables to be at top of the file")
+	rootCmd.PersistentFlags().BoolVar(&cfg.Flags.SeparateLogicalBlocks, "separate-logical-blocks", false, "don't enforce trimming of all blank lines")
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4,6 +4,8 @@ type ConfigFlags struct {
 	Check   bool
 	Verbose bool
 	Version bool
+	InRequestVars bool
+	SeparateLogicalBlocks bool
 }
 
 type Config struct {


### PR DESCRIPTION
## Formatting options

Logical blocks can be separated by a newline using `--separatelogicalblocks`. For example:

```http
@variables1=value1

# This is a comment
# This is another comment

# @someother metatag
# @name REQUEST_NAME_ONE

GET http://localhost:8080/api/v1/health HTTP/1.1
Content-Type: application/json

{
  "key": "value"
}
```

When using request variables (like optaining a token from a previous request) you may assign thie to a document after the request and don't force to put it at the top of the file.
This can be done by using `--inrequestvars`

```http
###

# @name login

POST {{loginURL}} HTTP/1.1
Accept: application/json
Content-Type: application/x-www-form-urlencoded

client_secret={{clientSecret}}&client_id={{clientId}}&grant_type=client_credentials&scope={{scope}}

###

@token = {{login.response.body.$.access_token}}
@tokentype = {{login.response.body.$.token_type}}

###
```
