### PR TITLE
feat: support stdin input for check and format commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,12 @@ Format specific `.http` and `.rest` files.
 kulala-fmt format file1.http file2.rest http/*.http
 ```
 
+Format stdin input:
+
+```sh
+cat SOMEFILE.http | kulala-fmt format --stdin
+```
+
 ### Check
 
 Check if all `.http` and `.rest` files in the current directory and its subdirectories are formatted:
@@ -75,6 +81,12 @@ prints the desired output to the console:
 
 ```sh
 kulala-fmt check --verbose file1.http file2.rest http/*.http
+```
+
+Check stdin input:
+
+```sh
+cat SOMEFILE.http | kulala-fmt format --stdin
 ```
 
 ### Convert

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -15,7 +15,7 @@ program
   .description("Format files")
   .argument("[files]", "files to include", null)
   .option("--body", "also format the body", true)
-  .option("--stdin", "read from stdin and print output to stdout", false)
+  .option("--stdin", "read input from stdin, print output to stdout", false)
   .action(async (files, options) => {
     await format(files, options);
   });
@@ -26,6 +26,7 @@ program
   .argument("[files]", "files to include", null)
   .option("-v, --verbose", "enable verbose mode", false)
   .option("--body", "also format the body", true)
+  .option("--stdin", "read input from stdin", false)
   .action(async (files, options) => {
     await check(files, options);
   });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -15,6 +15,7 @@ program
   .description("Format files")
   .argument("[files]", "files to include", null)
   .option("--body", "also format the body", true)
+  .option("--stdin", "read from stdin and print output to stdout", false)
   .action(async (files, options) => {
     await format(files, options);
   });

--- a/src/lib/parser/index.ts
+++ b/src/lib/parser/index.ts
@@ -53,13 +53,23 @@ const makeFilePretty = async (
 };
 
 const getStdinContent = async () => {
-  let content = "";
+  try {
+    let content = "";
 
-  for await (const chunk of process.stdin) {
-    content += chunk.toString();
+    for await (const chunk of process.stdin) {
+      content += chunk.toString();
+    }
+
+    return content;
+  } catch (error) {
+    console.error(
+      chalk.red(
+        `Error reading stdin: ${error instanceof Error ? error?.message || error : error}`,
+      ),
+    );
+
+    return process.exit(1);
   }
-
-  return content;
 };
 
 const checkStdin = async (options: { body: boolean; verbose: boolean }) => {

--- a/src/lib/parser/index.ts
+++ b/src/lib/parser/index.ts
@@ -8,6 +8,7 @@ import { Diff } from "./Diff";
 import { OpenAPIDocumentParser, OpenAPISpec } from "./OpenAPIDocumentParser";
 import { PostmanDocumentParser } from "./PostmanDocumentParser";
 import { BrunoDocumentParser } from "./BrunoDocumentParser";
+import * as process from "process";
 
 const OpenAPIParser = new OpenAPIDocumentParser();
 const PostmanParser = new PostmanDocumentParser();
@@ -91,11 +92,40 @@ export const check = async (
   }
 };
 
+const getStdinContent = () => {
+  return new Promise<string>((resolve, reject) => {
+    let content = "";
+
+    process.stdin.on("data", (d) => {
+      content += d.toString();
+    });
+
+    process.stdin.on("end", () => {
+      resolve(content);
+    });
+
+    process.stdin.on("error", (error) => {
+      reject(error);
+    });
+  });
+};
+
+export const formatStdin = async () => {
+  const content = await getStdinContent();
+
+  console.log(content);
+};
+
 export const format = async (
   dirPath: string | null,
-  options: { body: boolean },
+  options: { body: boolean; stdin: boolean },
   extensions: string[] | undefined = undefined,
 ): Promise<void> => {
+  if (options?.stdin) {
+    await formatStdin();
+    return;
+  }
+
   if (!dirPath) {
     dirPath = process.cwd();
   }


### PR DESCRIPTION
When playing around with kulala-fmt I ran into #32. This should act as a workaround for format runners that support stdin > stdout 😄 

Supporting stdin input also makes it possible to use kulala-fmt in tools that only support stdin, like the Helix editor ([https://docs.helix-editor.com/languages.html](https://docs.helix-editor.com/languages.html)).

