### PR TITLE
chore: bump version to 2.10.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mistweaverco/kulala-fmt",
-  "version": "2.10.0",
+  "version": "2.10.1",
   "type": "module",
   "scripts": {
     "build": "rollup -c",


### PR DESCRIPTION
Sorry, forgot to bump the version, for kulala.nvim to pick up the changes.