### PR TITLE
Add http-to-postman conversion and fix convert pipeline gaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ export KULALA_CORE_PATH=/path/to/kulala-core
 
 kulala-fmt can `fix`(alias `format`) and `check` `.http` and `.rest` files.
 
-It can also `convert` OpenAPI `.yaml`, `.yml` or `.json` files to `.http` files.
+It can also `convert` between `.http` files and other API formats (OpenAPI, Postman, Bruno).
 
 ### Format / Fix
 
@@ -130,12 +130,17 @@ cat SOMEFILE.http | kulala-fmt check --stdin
 
 ### Convert
 
-#### OpenAPI to `.http`
+kulala-fmt supports bidirectional conversion between `.http` files and several API formats.
+Use `--from` and `--to` to select the source and destination format (defaults: `openapi` → `http`).
 
-Convert OpenAPI `.yaml`, `.yml` or `.json` files to `.http` files:
+#### OpenAPI / Swagger to `.http`
+
+Convert OpenAPI 3.x or Swagger 2.0 `.yaml`, `.yml` or `.json` files to `.http` files.
+Query, path, header, and request body parameters are included; Swagger 2.0 `definitions` and `in: body` parameters are supported.
 
 ```sh
 kulala-fmt convert --from openapi openapi.yaml
+kulala-fmt convert swagger.json
 ```
 
 #### Postman collection to `.http`
@@ -146,9 +151,28 @@ Convert Postman collection `.json` files to `.http` files:
 kulala-fmt convert --from postman postman.json
 ```
 
+#### `.http` to Postman collection
+
+Convert one or more `.http` / `.rest` files (or a directory) to a Postman Collection v2.1 `.json` file.
+Directory structure is preserved as Postman folders.
+
+```sh
+kulala-fmt convert --from http --to postman requests.http
+kulala-fmt convert --from http --to postman ./api/
+kulala-fmt convert --from http --to postman *.http -o my-collection.json
+```
+
+Inject variables from an environment file:
+
+```sh
+kulala-fmt convert --from http --to postman requests.http --env .env
+kulala-fmt convert --from http --to postman requests.http --env http-client.env.json
+```
+
 #### Bruno to `.http`
 
-Convert Bruno collections to `.http` files:
+Convert Bruno collections to `.http` files.
+Request variables (`vars:pre-request`), environment variables, query/path params, and scripts are preserved.
 
 ```sh
 kulala-fmt convert --from bruno path/to/bruno/collection

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -33,10 +33,12 @@ program
 
 program
   .command('convert')
-  .description('Convert files to .http format')
+  .description('Convert between HTTP and other API formats')
   .argument('<files...>', 'files to include')
-  .option('--from <value>', 'source format', 'openapi')
-  .option('--to <value>', 'destination format', 'http')
+  .option('--from <value>', 'source format (openapi, postman, bruno, http)', 'openapi')
+  .option('--to <value>', 'destination format (http, postman)', 'http')
+  .option('--env <path>', 'environment file for variable injection (.env or http-client.env.json)')
+  .option('-o, --output <path>', 'output file path')
   .action(async (files, options) => {
     await convert(options, files);
   });

--- a/src/lib/kulala-core/index.ts
+++ b/src/lib/kulala-core/index.ts
@@ -1,6 +1,9 @@
 import { spawnSync } from 'child_process';
 import { downloader } from '../downloader';
 import { configparser } from '../configparser';
+import type { KulalaParsedDocument } from './types';
+
+export type { KulalaParsedDocument } from './types';
 
 export type FormatOptions = {
   formatBody?: boolean;
@@ -78,6 +81,17 @@ export async function formatHttp(content: string, options: FormatOptions = {}): 
   return response.formatted;
 }
 
+export async function parseHttp(content: string, filepath?: string): Promise<KulalaParsedDocument> {
+  await executablePath();
+
+  return invoke({
+    action: 'parse',
+    content,
+    filepath,
+  }) as KulalaParsedDocument;
+}
+
 export const kulalaCore = {
   formatHttp,
+  parseHttp,
 };

--- a/src/lib/kulala-core/types.ts
+++ b/src/lib/kulala-core/types.ts
@@ -1,0 +1,38 @@
+export interface KulalaOperator {
+  name: string;
+  args?: string;
+  commentStyle?: '#' | '//';
+}
+
+export interface KulalaComment {
+  content: string;
+}
+
+export interface KulalaHeaderSectionEntry {
+  type: 'header' | 'comment';
+  name?: string;
+  value?: string;
+  comment?: KulalaComment;
+}
+
+export interface KulalaBlock {
+  name: string;
+  preamble: Array<KulalaOperator | KulalaComment>;
+  comments: KulalaComment[];
+  operators: KulalaOperator[];
+  request: {
+    method: string;
+    url: string;
+    headerSection: KulalaHeaderSectionEntry[];
+    body?: string | object;
+    sourceBodyText?: string;
+  };
+  preambleVariables?: Record<string, string>;
+}
+
+export interface KulalaParsedDocument {
+  filepath?: string;
+  variables?: Record<string, string | number | boolean>;
+  fileHeaderVariables?: Record<string, string>;
+  blocks: KulalaBlock[];
+}

--- a/src/lib/parser/BrunoDocumentParser.ts
+++ b/src/lib/parser/BrunoDocumentParser.ts
@@ -19,6 +19,19 @@ interface EnvironmentInfo {
   vars: Record<string, string>;
 }
 
+interface BrunoParam {
+  name: string;
+  value: string;
+  enabled?: boolean;
+  type?: 'query' | 'path';
+}
+
+interface BrunoVar {
+  name: string;
+  value: string;
+  local?: boolean;
+}
+
 interface BrunoRequest {
   meta?: {
     name?: string;
@@ -29,6 +42,11 @@ interface BrunoRequest {
     url?: string;
   };
   headers?: BrunoHeader[];
+  params?: BrunoParam[];
+  vars?: {
+    req?: BrunoVar[];
+    res?: BrunoVar[];
+  };
   body?: {
     json?: string;
     graphql?: {
@@ -42,7 +60,10 @@ interface BrunoRequest {
       type?: string;
     }>;
   };
-  'script:pre-request'?: string;
+  script?: {
+    req?: string;
+    res?: string;
+  };
   tests?: string;
 }
 
@@ -81,7 +102,7 @@ export class BrunoDocumentParser {
 
       if (isInVarsBlock && environment.vars) {
         const [key, ...valueParts] = trimmedLine.split(':').map((part) => part.trim());
-        const value = valueParts.join(':').replace(/^"(.*)"$/, '$1'); // Remove quotes if present
+        const value = valueParts.join(':').replace(/^"(.*)"$/, '$1');
         if (key && value) {
           environment.vars[key] = value;
         }
@@ -91,7 +112,55 @@ export class BrunoDocumentParser {
     return environment;
   }
 
-  private buildRequestBlock(bruRequest: BrunoRequest, folderPath: string): Block {
+  private applyParams(url: string, params: BrunoParam[]): string {
+    let result = url;
+
+    for (const param of params.filter((p) => p.enabled !== false)) {
+      if (param.type === 'path') {
+        result = result
+          .replace(`:${param.name}`, param.value)
+          .replace(`{${param.name}}`, param.value);
+      }
+    }
+
+    const queryParams = params.filter((p) => p.type === 'query' && p.enabled !== false);
+    if (queryParams.length > 0) {
+      const queryParts = queryParams.map((p) => {
+        const value = p.value.match(/^{{.*}}$/) ? p.value : encodeURIComponent(p.value);
+        return `${encodeURIComponent(p.name)}=${value}`;
+      });
+      const separator = result.includes('?') ? '&' : '?';
+      result += separator + queryParts.join('&');
+    }
+
+    return result;
+  }
+
+  private applyVariables(block: Block, document: Document, vars: BrunoVar[] | undefined): void {
+    if (!vars?.length) return;
+
+    for (const variable of vars) {
+      const entry: Variable = {
+        key: variable.name,
+        value: variable.value,
+      };
+
+      if (variable.local) {
+        if (!block.variables) {
+          block.variables = [];
+        }
+        block.variables.push(entry);
+      } else if (!document.variables.some((v) => v.key === entry.key)) {
+        document.variables.push(entry);
+      }
+    }
+  }
+
+  private buildRequestBlock(
+    bruRequest: BrunoRequest,
+    folderPath: string,
+    document: Document,
+  ): Block {
     const request = {
       method: (bruRequest.http?.method || 'POST').toUpperCase(),
       url: bruRequest.http?.url || bruRequest.meta?.url || '',
@@ -99,6 +168,10 @@ export class BrunoDocumentParser {
       headers: [] as Header[],
       body: null as string | null,
     };
+
+    if (bruRequest.params?.length) {
+      request.url = this.applyParams(request.url, bruRequest.params);
+    }
 
     const block: Block = {
       requestSeparator: {
@@ -112,7 +185,6 @@ export class BrunoDocumentParser {
       responseRedirect: null,
     };
 
-    // Add folder path and name as comments
     if (folderPath) {
       block.comments.push(`# Folder: ${folderPath}\n`);
     }
@@ -124,7 +196,8 @@ export class BrunoDocumentParser {
       });
     }
 
-    // Handle headers - they come as array of { name, value, enabled }
+    this.applyVariables(block, document, bruRequest.vars?.req);
+
     if (Array.isArray(bruRequest.headers)) {
       bruRequest.headers
         .filter((header) => header.enabled !== false)
@@ -136,7 +209,6 @@ export class BrunoDocumentParser {
         });
     }
 
-    // Handle GraphQL specific headers and body
     if (bruRequest.body?.graphql) {
       request.headers.push(
         { key: 'Accept', value: 'application/json' },
@@ -166,18 +238,13 @@ export class BrunoDocumentParser {
       const formEntries = bruRequest.body.formUrlEncoded;
       const formParts: string[] = [];
 
-      // Log the form data for debugging
-      console.log('Form data:', formEntries);
-
       if (Array.isArray(formEntries)) {
         formEntries
           .filter((entry) => entry.enabled !== false)
           .forEach((entry) => {
             if (entry.name && entry.value !== undefined && entry.value !== null) {
               const value = String(entry.value);
-              // Don't encode {{variables}}
               const encodedValue = value.match(/^{{.*}}$/) ? value : encodeURIComponent(value);
-
               formParts.push(`${encodeURIComponent(entry.name)}=${encodedValue}`);
             }
           });
@@ -210,10 +277,9 @@ export class BrunoDocumentParser {
       });
     }
 
-    // Handle scripts
-    if (bruRequest['script:pre-request']) {
+    if (bruRequest.script?.req) {
       block.preRequestScripts.push({
-        script: bruRequest['script:pre-request'].trim(),
+        script: bruRequest.script.req.trim(),
         inline: true,
       });
     }
@@ -228,38 +294,28 @@ export class BrunoDocumentParser {
     return block;
   }
 
-  private processDirectory(dirPath: string): Document {
-    const document: Document = {
-      variables: [],
-      blocks: [],
-    };
-
+  private processDirectory(dirPath: string, document: Document): void {
     const items = readdirSync(dirPath);
 
     for (const item of items) {
       const fullPath = join(dirPath, item);
       const stat = statSync(fullPath);
 
-      // Skip the environments directory completely
       if (item === 'environments') {
         continue;
       }
 
       if (stat.isDirectory()) {
-        const subDocument = this.processDirectory(fullPath);
-        document.blocks.push(...subDocument.blocks);
-        document.variables.push(...subDocument.variables);
+        this.processDirectory(fullPath, document);
       } else if (item.endsWith('.bru')) {
         const content = readFileSync(fullPath, 'utf-8');
         const bruRequest = BrunoToJSONParser.parse(content) as BrunoRequest;
         const relativePath = relative(dirPath, fullPath).replace('.bru', '');
 
-        const block = this.buildRequestBlock(bruRequest, relativePath);
+        const block = this.buildRequestBlock(bruRequest, relativePath, document);
         document.blocks.push(block);
       }
     }
-
-    return document;
   }
 
   private getEnvironments(dirPath: string): EnvironmentInfo[] {
@@ -296,29 +352,29 @@ export class BrunoDocumentParser {
   }
 
   parse(collectionPath: string): ParseResult {
-    // Read collection info first
     collectionInfo = this.readCollectionInfo(collectionPath);
     const environments = this.getEnvironments(collectionPath);
 
-    // If no environments found, create a default document
     if (environments.length === 0) {
+      const document: Document = { variables: [], blocks: [] };
+      this.processDirectory(collectionPath, document);
       return {
-        documents: [this.processDirectory(collectionPath)],
+        documents: [document],
         environmentNames: ['default'],
         collectionName: collectionInfo?.name || 'bruno-collection',
       };
     }
 
-    // Create a document for each environment
     const documents = environments.map((env) => {
-      const doc = this.processDirectory(collectionPath);
-      // Add environment variables to the document
-      doc.variables = Object.entries(env.vars).map(
-        ([key, value]): Variable => ({
-          key,
-          value,
-        }),
-      );
+      const doc: Document = { variables: [], blocks: [] };
+      this.processDirectory(collectionPath, doc);
+
+      for (const [key, value] of Object.entries(env.vars)) {
+        if (!doc.variables.some((v) => v.key === key)) {
+          doc.variables.push({ key, value });
+        }
+      }
+
       return doc;
     });
 

--- a/src/lib/parser/DocumentParser.ts
+++ b/src/lib/parser/DocumentParser.ts
@@ -39,6 +39,7 @@ export interface Block {
   requestSeparator: BlockRequestSeparator;
   metadata: Metadata[];
   comments: string[];
+  variables?: Variable[];
   request: Request | null;
   preRequestScripts: PreRequestScript[];
   postRequestScripts: PostRequestScript[];

--- a/src/lib/parser/DocumentSerializer.ts
+++ b/src/lib/parser/DocumentSerializer.ts
@@ -33,6 +33,10 @@ export function documentToHttp(document: Document): string {
       output += `# @${metadata.key} ${metadata.value}\n`;
     }
 
+    for (const variable of block.variables ?? []) {
+      output += `@${variable.key} = ${variable.value}\n`;
+    }
+
     if (block.request) {
       output += `${block.request.method} ${block.request.url}`;
       if (

--- a/src/lib/parser/OpenAPIDocumentParser.ts
+++ b/src/lib/parser/OpenAPIDocumentParser.ts
@@ -14,23 +14,27 @@ interface OpenAPIServer {
 }
 
 interface OpenAPIParameter {
+  $ref?: string;
   name: string;
-  in: 'query' | 'header' | 'path' | 'cookie';
+  in: 'query' | 'header' | 'path' | 'cookie' | 'body' | 'formData';
   description?: string;
   required?: boolean;
   deprecated?: boolean;
   example?: string | number | boolean;
   schema?: OpenAPISchema;
+  type?: string;
 }
 
 interface OpenAPISchema {
-  type: 'string' | 'number' | 'integer' | 'boolean' | 'array' | 'object';
+  $ref?: string;
+  type?: 'string' | 'number' | 'integer' | 'boolean' | 'array' | 'object';
   format?: string;
   properties?: Record<string, OpenAPISchema>;
   items?: OpenAPISchema;
   required?: string[];
   description?: string;
   example?: OpenAPISchemaExample;
+  default?: OpenAPISchemaExample;
 }
 
 type OpenAPISchemaExample =
@@ -42,6 +46,7 @@ type OpenAPISchemaExample =
   | { [key: string]: OpenAPISchemaExample };
 
 interface OpenAPIRequestBody {
+  $ref?: string;
   description?: string;
   required?: boolean;
   content: Record<
@@ -59,6 +64,8 @@ interface OpenAPIOperation {
   operationId?: string;
   parameters?: OpenAPIParameter[];
   requestBody?: OpenAPIRequestBody;
+  consumes?: string[];
+  produces?: string[];
   responses?: Record<
     string,
     {
@@ -100,6 +107,34 @@ export interface OpenAPISpec {
   };
 }
 
+interface Swagger2Spec {
+  swagger: string;
+  host?: string;
+  basePath?: string;
+  schemes?: string[];
+  consumes?: string[];
+  produces?: string[];
+  info: {
+    title: string;
+    version: string;
+    description?: string;
+  };
+  paths: Record<string, Swagger2PathItem>;
+  definitions?: Record<string, OpenAPISchema>;
+  parameters?: Record<string, OpenAPIParameter>;
+}
+
+interface Swagger2PathItem {
+  get?: Swagger2Operation;
+  post?: Swagger2Operation;
+  put?: Swagger2Operation;
+  delete?: Swagger2Operation;
+  patch?: Swagger2Operation;
+  parameters?: OpenAPIParameter[];
+}
+
+type Swagger2Operation = OpenAPIOperation;
+
 interface OpenAPIParser {
   parse(openAPISpec: OpenAPISpec): ParseResult;
 }
@@ -109,8 +144,286 @@ interface ParseResult {
   serverUrls: string[];
 }
 
+const HTTP_METHODS = ['get', 'post', 'put', 'delete', 'patch'] as const;
+
+function isSwagger2Spec(spec: unknown): spec is Swagger2Spec {
+  return (
+    typeof spec === 'object' &&
+    spec !== null &&
+    'swagger' in spec &&
+    typeof (spec as Swagger2Spec).swagger === 'string'
+  );
+}
+
+function rewriteSwaggerRefs<T>(value: T): T {
+  if (value === null || value === undefined) {
+    return value;
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((item) => rewriteSwaggerRefs(item)) as T;
+  }
+
+  if (typeof value === 'object') {
+    const record = value as Record<string, unknown>;
+    if (typeof record.$ref === 'string') {
+      if (record.$ref.startsWith('#/definitions/')) {
+        return {
+          ...record,
+          $ref: record.$ref.replace('#/definitions/', '#/components/schemas/'),
+        } as T;
+      }
+      if (record.$ref.startsWith('#/parameters/')) {
+        return {
+          ...record,
+          $ref: record.$ref.replace('#/parameters/', '#/components/parameters/'),
+        } as T;
+      }
+    }
+
+    const result: Record<string, unknown> = {};
+    for (const [key, entry] of Object.entries(record)) {
+      result[key] = rewriteSwaggerRefs(entry);
+    }
+    return result as T;
+  }
+
+  return value;
+}
+
+function convertSwagger2ToOpenAPI(spec: Swagger2Spec): OpenAPISpec {
+  const schemes = spec.schemes?.length ? spec.schemes : ['https'];
+  const host = spec.host || 'localhost';
+  const basePath = (spec.basePath || '').replace(/\/$/, '');
+
+  const servers: OpenAPIServer[] = schemes.map((scheme) => ({
+    url: `${scheme}://${host}${basePath}`,
+  }));
+
+  const paths: Record<string, OpenAPIPathItem> = {};
+
+  for (const [path, pathItem] of Object.entries(spec.paths)) {
+    const convertedPathItem: OpenAPIPathItem = {};
+
+    if (pathItem.parameters) {
+      convertedPathItem.parameters = pathItem.parameters;
+    }
+
+    for (const method of HTTP_METHODS) {
+      const operation = pathItem[method];
+      if (!operation) continue;
+
+      const consumes = operation.consumes ?? spec.consumes ?? ['application/json'];
+      const convertedOperation: OpenAPIOperation = { ...operation };
+      const nonBodyParams: OpenAPIParameter[] = [];
+
+      if (operation.parameters) {
+        for (const param of operation.parameters) {
+          if (param.in === 'body') {
+            const contentType = consumes[0] || 'application/json';
+            convertedOperation.requestBody = {
+              required: param.required,
+              content: {
+                [contentType]: {
+                  schema: param.schema,
+                },
+              },
+            };
+          } else if (param.in !== 'formData') {
+            nonBodyParams.push(param);
+          }
+        }
+        convertedOperation.parameters = nonBodyParams;
+      }
+
+      convertedPathItem[method] = convertedOperation;
+    }
+
+    paths[path] = convertedPathItem;
+  }
+
+  return rewriteSwaggerRefs({
+    openapi: '3.0.0',
+    info: spec.info,
+    servers,
+    paths,
+    components: {
+      schemas: spec.definitions,
+      parameters: spec.parameters,
+    },
+  });
+}
+
+export function normalizeSpec(spec: unknown): OpenAPISpec {
+  if (isSwagger2Spec(spec)) {
+    return convertSwagger2ToOpenAPI(spec);
+  }
+  return spec as OpenAPISpec;
+}
+
 export class OpenAPIDocumentParser implements OpenAPIParser {
-  private buildRequestBlock(path: string, method: string, operation: OpenAPIOperation): Block {
+  private resolveRef<T extends object>(ref: string, spec: OpenAPISpec): T | undefined {
+    const normalizedRef = ref.startsWith('#/definitions/')
+      ? ref.replace('#/definitions/', '#/components/schemas/')
+      : ref;
+
+    if (!normalizedRef.startsWith('#/')) return undefined;
+
+    const parts = normalizedRef.slice(2).split('/');
+    let current: unknown = spec;
+
+    for (const part of parts) {
+      if (typeof current !== 'object' || current === null || !(part in current)) {
+        return undefined;
+      }
+      current = (current as Record<string, unknown>)[part];
+    }
+
+    return current as T;
+  }
+
+  private resolveParameter(param: OpenAPIParameter, spec: OpenAPISpec): OpenAPIParameter {
+    if (param.$ref) {
+      const resolved = this.resolveRef<OpenAPIParameter>(param.$ref, spec);
+      if (resolved) {
+        return this.resolveParameter(resolved, spec);
+      }
+    }
+    return param;
+  }
+
+  private mergeParameters(
+    pathParams: OpenAPIParameter[] = [],
+    operationParams: OpenAPIParameter[] = [],
+    spec: OpenAPISpec,
+  ): OpenAPIParameter[] {
+    const merged = new Map<string, OpenAPIParameter>();
+
+    for (const param of [...pathParams, ...operationParams]) {
+      const resolved = this.resolveParameter(param, spec);
+      merged.set(`${resolved.in}:${resolved.name}`, resolved);
+    }
+
+    return Array.from(merged.values());
+  }
+
+  private getParameterValue(param: OpenAPIParameter): string {
+    if (param.example !== undefined) {
+      return String(param.example);
+    }
+    if (param.schema?.example !== undefined && typeof param.schema.example !== 'object') {
+      return String(param.schema.example);
+    }
+    if (param.schema?.default !== undefined && typeof param.schema.default !== 'object') {
+      return String(param.schema.default);
+    }
+    return `{{${param.name}}}`;
+  }
+
+  private applyParameters(
+    url: string,
+    parameters: OpenAPIParameter[],
+    spec: OpenAPISpec,
+  ): { url: string; headers: Header[] } {
+    const headers: Header[] = [];
+    const queryParts: string[] = [];
+
+    for (const param of parameters) {
+      const resolved = this.resolveParameter(param, spec);
+      const value = this.getParameterValue(resolved);
+
+      switch (resolved.in) {
+        case 'query':
+          queryParts.push(`${encodeURIComponent(resolved.name)}=${value}`);
+          break;
+        case 'path':
+          url = url.replace(`{${resolved.name}}`, value);
+          break;
+        case 'header':
+          headers.push({ key: resolved.name, value });
+          break;
+        case 'cookie':
+          headers.push({ key: 'Cookie', value: `${resolved.name}=${value}` });
+          break;
+      }
+    }
+
+    if (queryParts.length > 0) {
+      const separator = url.includes('?') ? '&' : '?';
+      url += separator + queryParts.join('&');
+    }
+
+    return { url, headers };
+  }
+
+  private resolveRequestBody(
+    requestBody: OpenAPIRequestBody | undefined,
+    spec: OpenAPISpec,
+  ): OpenAPIRequestBody | undefined {
+    if (!requestBody) return undefined;
+
+    if (requestBody.$ref) {
+      const resolved = this.resolveRef<OpenAPIRequestBody>(requestBody.$ref, spec);
+      return resolved ? this.resolveRequestBody(resolved, spec) : undefined;
+    }
+
+    return requestBody;
+  }
+
+  private generateExampleFromSchema(
+    schema: OpenAPISchema,
+    spec: OpenAPISpec,
+    visited = new Set<string>(),
+  ): unknown {
+    if (schema.$ref) {
+      if (visited.has(schema.$ref)) {
+        return {};
+      }
+      visited.add(schema.$ref);
+      const resolved = this.resolveRef<OpenAPISchema>(schema.$ref, spec);
+      if (resolved) {
+        return this.generateExampleFromSchema(resolved, spec, visited);
+      }
+      return {};
+    }
+
+    if (schema.example !== undefined) {
+      return schema.example;
+    }
+
+    switch (schema.type) {
+      case 'string':
+        return schema.format === 'date-time' ? new Date().toISOString() : 'string';
+      case 'number':
+      case 'integer':
+        return 0;
+      case 'boolean':
+        return false;
+      case 'array':
+        return schema.items ? [this.generateExampleFromSchema(schema.items, spec, visited)] : [];
+      case 'object':
+      default: {
+        const example: Record<string, unknown> = {};
+        if (schema.properties) {
+          for (const [key, prop] of Object.entries(schema.properties)) {
+            example[key] = this.generateExampleFromSchema(prop, spec, visited);
+          }
+        }
+        return example;
+      }
+    }
+  }
+
+  private buildRequestBlock(
+    path: string,
+    method: string,
+    operation: OpenAPIOperation,
+    pathParameters: OpenAPIParameter[] = [],
+    spec: OpenAPISpec,
+  ): Block {
+    const parameters = this.mergeParameters(pathParameters, operation.parameters, spec);
+    const { url, headers: paramHeaders } = this.applyParameters(path, parameters, spec);
+
     const block: Block = {
       requestSeparator: {
         text: null,
@@ -119,9 +432,9 @@ export class OpenAPIDocumentParser implements OpenAPIParser {
       comments: [],
       request: {
         method: method.toUpperCase(),
-        url: path,
+        url,
         httpVersion: 'HTTP/1.1',
-        headers: [],
+        headers: [...paramHeaders],
         body: null,
       },
       preRequestScripts: [],
@@ -129,7 +442,6 @@ export class OpenAPIDocumentParser implements OpenAPIParser {
       responseRedirect: null,
     };
 
-    // Add operation summary/description as comments
     if (operation.summary) {
       block.comments.push(
         operation.summary
@@ -147,7 +459,6 @@ export class OpenAPIDocumentParser implements OpenAPIParser {
       );
     }
 
-    // Add operationId as metadata
     if (operation.operationId) {
       block.metadata.push({
         key: 'name',
@@ -155,37 +466,23 @@ export class OpenAPIDocumentParser implements OpenAPIParser {
       });
     }
 
-    // Since we know block.request is initialized above, we can assert it's non-null
-    if (operation.requestBody?.content) {
-      const content = operation.requestBody.content;
-      const contentType = Object.keys(content)[0];
+    const requestBody = this.resolveRequestBody(operation.requestBody, spec);
+    if (requestBody?.content && block.request) {
+      const contentTypes = Object.keys(requestBody.content);
+      const preferred = contentTypes.find((ct) => ct.includes('json')) ?? contentTypes[0];
 
-      if (block.request) {
-        // TypeScript guard
+      if (preferred) {
         block.request.headers.push({
           key: 'Content-Type',
-          value: contentType,
+          value: preferred,
         });
 
-        const mediaTypeObject = content[contentType];
-        if (mediaTypeObject.example) {
+        const mediaTypeObject = requestBody.content[preferred];
+        if (mediaTypeObject?.example) {
           block.request.body = JSON.stringify(mediaTypeObject.example, null, 2);
-        } else if (mediaTypeObject.schema) {
-          block.request.body = this.generateExampleFromSchema(mediaTypeObject.schema);
-        }
-      }
-    }
-
-    // Handle parameters
-    if (operation.parameters && block.request) {
-      // TypeScript guard
-      for (const param of operation.parameters) {
-        if (param.in === 'header') {
-          const header: Header = {
-            key: param.name,
-            value: param.example?.toString() || `{{${param.name}}}`,
-          };
-          block.request.headers.push(header);
+        } else if (mediaTypeObject?.schema) {
+          const example = this.generateExampleFromSchema(mediaTypeObject.schema, spec);
+          block.request.body = JSON.stringify(example, null, 2);
         }
       }
     }
@@ -193,53 +490,21 @@ export class OpenAPIDocumentParser implements OpenAPIParser {
     return block;
   }
 
-  private generateExampleFromSchema(schema: OpenAPISchema): string {
-    const example: Record<string, unknown> = {};
-    if (schema.properties) {
-      for (const [key, prop] of Object.entries(schema.properties)) {
-        example[key] = prop.example || this.getDefaultValueForType(prop.type);
-      }
-    }
-    return JSON.stringify(example, null, 2);
-  }
-
-  private getDefaultValueForType(type: OpenAPISchema['type']): unknown {
-    switch (type) {
-      case 'string':
-        return 'string';
-      case 'number':
-      case 'integer':
-        return 0;
-      case 'boolean':
-        return false;
-      case 'array':
-        return [];
-      case 'object':
-        return {};
-      default:
-        return null;
-    }
-  }
-
   private extractServerIdentifier(server: OpenAPIServer): string {
-    // Remove protocol prefix (http:// or https://)
     let identifier = server.url.replace(/^https?:\/\//, '');
 
-    // Replace variable patterns with their default values or placeholder
     if (server.variables) {
       Object.entries(server.variables).forEach(([key, variable]) => {
         identifier = identifier.replace(`{${key}}`, variable.default || `[${key}]`);
       });
     }
 
-    // Remove port and path for cleaner identifier
     identifier = identifier.split(':')[0].split('/')[0];
 
     return identifier;
   }
 
   parse(openAPISpec: OpenAPISpec): ParseResult {
-    // If no servers are specified, create a single document with relative URLs
     if (!openAPISpec.servers || openAPISpec.servers.length === 0) {
       return {
         documents: [this.createDocument(openAPISpec)],
@@ -247,12 +512,10 @@ export class OpenAPIDocumentParser implements OpenAPIParser {
       };
     }
 
-    // Create a document for each server
     const documents = openAPISpec.servers.map((server, index) =>
       this.createDocument(openAPISpec, server, index),
     );
 
-    // Extract server identifiers in matching order
     const serverUrls = openAPISpec.servers.map((server) => this.extractServerIdentifier(server));
 
     return {
@@ -266,19 +529,16 @@ export class OpenAPIDocumentParser implements OpenAPIParser {
       return path;
     }
 
-    // Remove leading slash from path
     const cleanPath = path.replace(/^\//, '');
 
     let url = server.url;
 
-    // Replace server variables with double curly brace format
     if (server.variables) {
       Object.keys(server.variables).forEach((key) => {
         url = url.replace(`{${key}}`, `{{${key}}}`);
       });
     }
 
-    // Replace the entire server URL with baseUrl variable
     url = `{{baseUrl${serverIndex || ''}}}/${cleanPath}`;
 
     return url;
@@ -294,11 +554,9 @@ export class OpenAPIDocumentParser implements OpenAPIParser {
       blocks: [],
     };
 
-    // Add server URL as a variable if it exists
     if (server) {
-      let serverUrl = server.url.replace(/\/$/, ''); // Remove trailing slash
+      let serverUrl = server.url.replace(/\/$/, '');
 
-      // Replace server variables with double curly braces in the URL
       if (server.variables) {
         Object.keys(server.variables).forEach((key) => {
           serverUrl = serverUrl.replace(`{${key}}`, `{{${key}}}`);
@@ -310,7 +568,6 @@ export class OpenAPIDocumentParser implements OpenAPIParser {
         value: serverUrl,
       });
 
-      // Add server variables if they exist
       if (server.variables) {
         Object.entries(server.variables).forEach(([key, variable]) => {
           document.variables.push({
@@ -321,23 +578,24 @@ export class OpenAPIDocumentParser implements OpenAPIParser {
       }
     }
 
-    // Parse paths into blocks
     for (const [path, pathItem] of Object.entries(openAPISpec.paths)) {
-      for (const [method, operation] of Object.entries(pathItem)) {
-        if (['get', 'post', 'put', 'delete', 'patch'].includes(method)) {
-          const block = this.buildRequestBlock(
-            this.buildFullUrl(path, server, serverIndex),
-            method,
-            operation as OpenAPIOperation,
-          );
+      for (const method of HTTP_METHODS) {
+        const operation = pathItem[method];
+        if (!operation) continue;
 
-          // Add server description as a comment if it exists
-          if (server?.description) {
-            block.comments.unshift(`# Server: ${server.description}\n`);
-          }
+        const block = this.buildRequestBlock(
+          this.buildFullUrl(path, server, serverIndex),
+          method,
+          operation,
+          pathItem.parameters,
+          openAPISpec,
+        );
 
-          document.blocks.push(block);
+        if (server?.description) {
+          block.comments.unshift(`# Server: ${server.description}\n`);
         }
+
+        document.blocks.push(block);
       }
     }
 

--- a/src/lib/parser/PostmanDocumentBuilder.ts
+++ b/src/lib/parser/PostmanDocumentBuilder.ts
@@ -1,0 +1,339 @@
+import { basename, dirname, resolve } from 'path';
+import { readFileSync } from 'fs';
+import type { KulalaParsedDocument } from '../kulala-core/types';
+
+interface PostmanVariable {
+  key: string;
+  value: string;
+  type?: string;
+}
+
+interface PostmanHeader {
+  key: string;
+  value: string;
+  type?: string;
+}
+
+interface PostmanUrl {
+  raw: string;
+  query?: Array<{
+    key: string;
+    value: string;
+    disabled?: boolean;
+  }>;
+}
+
+interface PostmanRequest {
+  method: string;
+  header: PostmanHeader[];
+  url: PostmanUrl;
+  body?: {
+    mode: 'raw';
+    raw: string;
+    options?: {
+      raw: {
+        language: string;
+      };
+    };
+  };
+  description?: string;
+}
+
+interface PostmanItem {
+  name: string;
+  request: PostmanRequest;
+  response: unknown[];
+}
+
+interface PostmanItemGroup {
+  name: string;
+  item: (PostmanItem | PostmanItemGroup)[];
+  description?: string;
+}
+
+export interface PostmanCollection {
+  info: {
+    name: string;
+    description?: string;
+    schema: string;
+  };
+  item: (PostmanItem | PostmanItemGroup)[];
+  variable?: PostmanVariable[];
+}
+
+function detectBodyLanguage(body: string, contentType?: string): string {
+  if (contentType?.includes('json')) return 'json';
+  if (contentType?.includes('xml')) return 'xml';
+  if (contentType?.includes('javascript')) return 'javascript';
+  if (body.trim().startsWith('{') || body.trim().startsWith('[')) return 'json';
+  return 'text';
+}
+
+function parseUrl(rawUrl: string): PostmanUrl {
+  const queryIndex = rawUrl.indexOf('?');
+  if (queryIndex === -1) {
+    return { raw: rawUrl };
+  }
+
+  const queryString = rawUrl.slice(queryIndex + 1);
+  const query = queryString.split('&').map((part) => {
+    const [key, ...valueParts] = part.split('=');
+    return {
+      key: decodeURIComponent(key || ''),
+      value: decodeURIComponent(valueParts.join('=')),
+    };
+  });
+
+  return { raw: rawUrl, query };
+}
+
+function getBlockName(doc: KulalaParsedDocument, blockIndex: number): string {
+  const block = doc.blocks[blockIndex];
+  if (!block) return `Request ${blockIndex + 1}`;
+
+  const nameOp = block.operators?.find((op) => op.name === 'name');
+  if (nameOp?.args) return String(nameOp.args);
+
+  if (block.name) return block.name;
+
+  return `Request ${blockIndex + 1}`;
+}
+
+function isComment(entry: KulalaParsedDocument['blocks'][number]['preamble'][number]): entry is {
+  content: string;
+} {
+  return 'content' in entry;
+}
+
+function getFolderPath(block: KulalaParsedDocument['blocks'][number]): string | null {
+  for (const entry of block.preamble) {
+    if (isComment(entry) && entry.content.startsWith('Folder: ')) {
+      return entry.content.slice('Folder: '.length).trim();
+    }
+  }
+
+  for (const comment of block.comments) {
+    if (comment.content.startsWith('Folder: ')) {
+      return comment.content.slice('Folder: '.length).trim();
+    }
+  }
+
+  return null;
+}
+
+function getBlockDescription(block: KulalaParsedDocument['blocks'][number]): string {
+  const lines: string[] = [];
+
+  for (const entry of block.preamble) {
+    if (isComment(entry) && !entry.content.startsWith('Folder: ')) {
+      lines.push(entry.content);
+    }
+  }
+
+  for (const comment of block.comments) {
+    if (!comment.content.startsWith('Folder: ')) {
+      lines.push(comment.content);
+    }
+  }
+
+  return lines.join('\n').trim();
+}
+
+function buildPostmanRequest(block: KulalaParsedDocument['blocks'][number]): PostmanRequest {
+  const headers: PostmanHeader[] = [];
+  let contentType: string | undefined;
+
+  for (const entry of block.request.headerSection) {
+    if (entry.type === 'header' && entry.name) {
+      headers.push({
+        key: entry.name,
+        value: entry.value ?? '',
+      });
+      if (entry.name.toLowerCase() === 'content-type') {
+        contentType = entry.value;
+      }
+    }
+  }
+
+  const request: PostmanRequest = {
+    method: block.request.method,
+    header: headers,
+    url: parseUrl(block.request.url),
+    description: getBlockDescription(block) || undefined,
+  };
+
+  const body =
+    typeof block.request.body === 'string'
+      ? block.request.body
+      : block.request.body
+        ? JSON.stringify(block.request.body, null, 2)
+        : block.request.sourceBodyText;
+
+  if (body) {
+    request.body = {
+      mode: 'raw',
+      raw: body,
+      options: {
+        raw: {
+          language: detectBodyLanguage(body, contentType),
+        },
+      },
+    };
+  }
+
+  return request;
+}
+
+function ensureFolder(
+  root: (PostmanItem | PostmanItemGroup)[],
+  folderPath: string,
+): PostmanItemGroup {
+  const parts = folderPath.split('/').filter(Boolean);
+  let currentItems = root;
+
+  let currentFolder: PostmanItemGroup | undefined;
+
+  for (const part of parts) {
+    let folder = currentItems.find(
+      (item): item is PostmanItemGroup => 'item' in item && item.name === part,
+    );
+
+    if (!folder) {
+      folder = { name: part, item: [] };
+      currentItems.push(folder);
+    }
+
+    currentFolder = folder;
+    currentItems = folder.item;
+  }
+
+  return currentFolder ?? { name: parts[parts.length - 1] || 'Requests', item: [] };
+}
+
+function addItemToFolder(
+  root: (PostmanItem | PostmanItemGroup)[],
+  folderPath: string | null,
+  item: PostmanItem,
+): void {
+  if (!folderPath) {
+    root.push(item);
+    return;
+  }
+
+  const folder = ensureFolder(root, folderPath);
+  folder.item.push(item);
+}
+
+export function buildPostmanCollection(
+  documents: Array<{ doc: KulalaParsedDocument; relativePath?: string }>,
+  collectionName: string,
+  extraVariables: Record<string, string> = {},
+): PostmanCollection {
+  const variables = new Map<string, string>();
+
+  for (const { doc } of documents) {
+    if (doc.fileHeaderVariables) {
+      for (const [key, value] of Object.entries(doc.fileHeaderVariables)) {
+        variables.set(key, value);
+      }
+    }
+
+    if (doc.variables) {
+      for (const [key, value] of Object.entries(doc.variables)) {
+        variables.set(key, String(value));
+      }
+    }
+
+    for (const block of doc.blocks) {
+      if (block.preambleVariables) {
+        for (const [key, value] of Object.entries(block.preambleVariables)) {
+          variables.set(key, value);
+        }
+      }
+    }
+  }
+
+  for (const [key, value] of Object.entries(extraVariables)) {
+    variables.set(key, value);
+  }
+
+  const item: (PostmanItem | PostmanItemGroup)[] = [];
+
+  for (const { doc, relativePath } of documents) {
+    const fileFolder =
+      documents.length > 1 && relativePath
+        ? relativePath.replace(/\.(http|rest)$/i, '').replace(/\\/g, '/')
+        : null;
+
+    doc.blocks.forEach((block, index) => {
+      if (!block.request?.method) return;
+
+      const folderFromComment = getFolderPath(block);
+      const folderPath = folderFromComment
+        ? fileFolder
+          ? `${fileFolder}/${folderFromComment}`
+          : folderFromComment
+        : fileFolder;
+
+      addItemToFolder(item, folderPath, {
+        name: getBlockName(doc, index),
+        request: buildPostmanRequest(block),
+        response: [],
+      });
+    });
+  }
+
+  return {
+    info: {
+      name: collectionName,
+      schema: 'https://schema.getpostman.com/json/collection/v2.1.0/collection.json',
+    },
+    item,
+    variable: Array.from(variables.entries()).map(([key, value]) => ({
+      key,
+      value,
+      type: 'string',
+    })),
+  };
+}
+
+export function resolveCollectionName(files: string[], fallback = 'kulala-collection'): string {
+  if (files.length === 1) {
+    return basename(files[0]!).replace(/\.(http|rest)$/i, '');
+  }
+
+  const dirs = new Set(files.map((file) => dirname(resolve(file))));
+  if (dirs.size === 1) {
+    return basename([...dirs][0]!);
+  }
+
+  return fallback;
+}
+
+export function loadEnvVariables(envPath: string): Record<string, string> {
+  const content = readFileSync(envPath, 'utf-8').trim();
+
+  if (envPath.endsWith('.json')) {
+    const parsed = JSON.parse(content) as Record<string, unknown>;
+    const firstEnv = Object.values(parsed).find((v) => typeof v === 'object' && v !== null) as
+      | Record<string, string>
+      | undefined;
+    const env = firstEnv ?? (parsed as Record<string, string>);
+    return Object.fromEntries(Object.entries(env).map(([key, value]) => [key, String(value)]));
+  }
+
+  const vars: Record<string, string> = {};
+  for (const line of content.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+    const eqIndex = trimmed.indexOf('=');
+    if (eqIndex === -1) continue;
+    const key = trimmed.slice(0, eqIndex).trim();
+    const value = trimmed
+      .slice(eqIndex + 1)
+      .trim()
+      .replace(/^["']|["']$/g, '');
+    if (key) vars[key] = value;
+  }
+  return vars;
+}

--- a/src/lib/parser/index.ts
+++ b/src/lib/parser/index.ts
@@ -1,11 +1,17 @@
 import fs from 'fs';
+import path from 'path';
 import chalk from 'chalk';
 import yaml from 'js-yaml';
 import { fileWalker } from './../filewalker';
 import { DocumentBuilder } from './DocumentBuilder';
 import { Diff } from './Diff';
-import { OpenAPIDocumentParser, OpenAPISpec } from './OpenAPIDocumentParser';
+import { OpenAPIDocumentParser, OpenAPISpec, normalizeSpec } from './OpenAPIDocumentParser';
 import { PostmanDocumentParser } from './PostmanDocumentParser';
+import {
+  buildPostmanCollection,
+  loadEnvVariables,
+  resolveCollectionName,
+} from './PostmanDocumentBuilder';
 import { BrunoDocumentParser } from './BrunoDocumentParser';
 import { kulalaCore } from '../kulala-core';
 
@@ -14,10 +20,13 @@ const PostmanParser = new PostmanDocumentParser();
 const BrunoParser = new BrunoDocumentParser();
 
 const getOpenAPISpecAsJSON = (filepath: string): OpenAPISpec => {
+  let raw: unknown;
   if (filepath.endsWith('.yaml') || filepath.endsWith('.yml')) {
-    return yaml.load(fs.readFileSync(filepath, 'utf-8')) as OpenAPISpec;
+    raw = yaml.load(fs.readFileSync(filepath, 'utf-8'));
+  } else {
+    raw = JSON.parse(fs.readFileSync(filepath, 'utf-8'));
   }
-  return JSON.parse(fs.readFileSync(filepath, 'utf-8')) as OpenAPISpec;
+  return normalizeSpec(raw);
 };
 
 const isAlreadyPretty = async (
@@ -223,13 +232,95 @@ const convertFromBruno = async (files: string[]): Promise<void> => {
   }
 };
 
+const collectHttpFiles = (inputs: string[]): string[] => {
+  const files = new Set<string>();
+
+  for (const input of inputs) {
+    const resolved = path.resolve(input);
+    if (!fs.existsSync(resolved)) {
+      console.log(chalk.red(`File not found: ${input}`));
+      process.exit(1);
+    }
+
+    const stat = fs.statSync(resolved);
+    if (stat.isDirectory()) {
+      for (const file of fileWalker(resolved, ['.http', '.rest'])) {
+        files.add(file);
+      }
+    } else if (resolved.endsWith('.http') || resolved.endsWith('.rest')) {
+      files.add(resolved);
+    } else {
+      console.log(chalk.red(`Unsupported file type: ${input}`));
+      process.exit(1);
+    }
+  }
+
+  return [...files].sort();
+};
+
+const convertToPostman = async (
+  files: string[],
+  options: { env?: string; output?: string },
+): Promise<void> => {
+  const httpFiles = collectHttpFiles(files);
+  if (httpFiles.length === 0) {
+    console.log(chalk.red('No .http or .rest files found.'));
+    process.exit(1);
+  }
+
+  const baseDir = httpFiles.length === 1 ? path.dirname(httpFiles[0]!) : commonBaseDir(httpFiles);
+  const extraVariables = options.env ? loadEnvVariables(options.env) : {};
+
+  const documents = await Promise.all(
+    httpFiles.map(async (file) => {
+      const content = fs.readFileSync(file, 'utf-8');
+      const doc = await kulalaCore.parseHttp(content, file);
+      return {
+        doc,
+        relativePath: path.relative(baseDir, file),
+      };
+    }),
+  );
+
+  const collectionName = resolveCollectionName(httpFiles);
+  const collection = buildPostmanCollection(documents, collectionName, extraVariables);
+
+  const outputFilename =
+    options.output ??
+    (httpFiles.length === 1
+      ? httpFiles[0]!.replace(/\.(http|rest)$/i, '.postman_collection.json')
+      : `${collectionName}.postman_collection.json`);
+
+  fs.writeFileSync(outputFilename, JSON.stringify(collection, null, 2), 'utf-8');
+  console.log(chalk.green(`Converted ${httpFiles.length} HTTP file(s) --> ${outputFilename}`));
+};
+
+const commonBaseDir = (files: string[]): string => {
+  if (files.length === 0) return process.cwd();
+
+  const parts = files.map((file) => path.resolve(file).split(path.sep));
+  const shortest = Math.min(...parts.map((p) => p.length));
+  const common: string[] = [];
+
+  for (let i = 0; i < shortest; i++) {
+    const segment = parts[0]![i];
+    if (parts.every((p) => p[i] === segment)) {
+      common.push(segment!);
+    } else {
+      break;
+    }
+  }
+
+  return common.join(path.sep) || path.dirname(files[0]!);
+};
+
 const invalidFormat = (t: 'src' | 'dest', format: string): void => {
   console.log(chalk.red(`Invalid ${t} format ${format}.`));
   process.exit(1);
 };
 
 export const convert = async (
-  options: { from: string; to: string },
+  options: { from: string; to: string; env?: string; output?: string },
   files: string[],
 ): Promise<void> => {
   switch (options.from) {
@@ -255,6 +346,15 @@ export const convert = async (
       switch (options.to) {
         case 'http':
           await convertFromBruno(files);
+          break;
+        default:
+          invalidFormat('dest', options.to);
+      }
+      break;
+    case 'http':
+      switch (options.to) {
+        case 'postman':
+          await convertToPostman(files, options);
           break;
         default:
           invalidFormat('dest', options.to);


### PR DESCRIPTION
## Summary
- Add `--from http --to postman` conversion with directory folder support, optional `--env` variable injection, and `-o` output path (#47)
- Fix OpenAPI conversion to include query, path, header, and cookie parameters with `$ref` resolution (#49)
- Fix Bruno conversion to preserve `vars:pre-request`, environment variables, query/path params, and pre-request scripts (#54)
- Add Swagger 2.0 support with request body generation from `definitions` schemas (#59)

## Test plan
- [x] `kulala-fmt convert swagger2.json` produces request body from `$ref` definitions
- [x] `kulala-fmt convert openapi-query.json` appends `?resources=...` query params to URL
- [x] `kulala-fmt convert --from bruno collection/` emits `@token` and `@localVar` variables
- [x] `kulala-fmt convert --from http --to postman file.http` outputs valid Postman Collection v2.1 JSON
- [x] `pnpm run build` and `pnpm run lint` pass

Closes #47, #49, #54, #59